### PR TITLE
Update permissions for control so depkg-deb will build.

### DIFF
--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -91,7 +91,7 @@ fi
 EOF
 chmod +x "$BUILD_DIR/DEBIAN/postinst"
 
-# Avoid dpkg-build failing due to content directory not 
+# Avoid dpkg-build failing due to control directory not
 # having other rX permissions.
 
 chmod -R a+rX .

--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -94,7 +94,7 @@ chmod +x "$BUILD_DIR/DEBIAN/postinst"
 # Avoid dpkg-build failing due to control directory not
 # having other rX permissions.
 
-chmod -R a+rX .
+chmod -R a+rX $BUILD_DIR
 
 # === BUILD THE DEB PACKAGE ===
 echo "Building .deb package..."

--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # === CONFIG ===
 PACKAGE_NAME="zen-browser"
-VERSION="1.11.5b"
+VERSION="1.14.7b"
 ARCH="amd64"
 TARBALL="zen.linux-x86_64.tar.xz"
 BUILD_DIR="${PACKAGE_NAME}_${VERSION}"
@@ -91,9 +91,14 @@ fi
 EOF
 chmod +x "$BUILD_DIR/DEBIAN/postinst"
 
+# Avoid dpkg-build failing due to content directory not 
+# having other rX permissions.
+
+chmod -R a+rX .
+
 # === BUILD THE DEB PACKAGE ===
 echo "Building .deb package..."
-dpkg-deb --build "$BUILD_DIR"
+dpkg-deb --build --root-owner-group "$BUILD_DIR"
 
 # === FINAL CLEANUP ===
 echo "Final cleanup..."


### PR DESCRIPTION
On my Ubuntu 25.04 system the create-zen-deb.sh was failing:

```
$ ./create-zen-deb.sh 
Extracting tarball...
Creating wrapper script...
Copying icons...
Creating .desktop file...
Creating control file...
Building .deb package...
dpkg-deb: error: control directory has bad permissions 750 (must be >=0755 and <=0775)
```

A simple `chmod -R a+rX .` before the `dpkg-deb` fixed it.