### PR TITLE
Extract version from tarball. New script to auto update.

### DIFF
--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 set -euo pipefail
 
-# === CONFIG ===
+# Check the TARBALL has been downloaded.
+
 TARBALL="zen.linux-x86_64.tar.xz"
+
+if [ ! -e "${TARBALL}" ]; then
+    echo "error: $0: Did not find the required tarball."
+    echo
+    echo "Please get the offical tarball '${TARBALL}' from"
+    echo
+    echo "  https://github.com/zen-browser/desktop/releases"
+    echo
+    exit 1
+fi
+
+
+# === CONFIG ===
 PACKAGE_NAME="zen-browser"
 VERSION=$(tar -xJf ${TARBALL} --to-stdout zen/application.ini | grep '^Version=' | cut -d'=' -f2)
 ARCH="amd64"

--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # === CONFIG ===
 PACKAGE_NAME="zen-browser"
-VERSION="1.14.7b"
+VERSION="1.14.9b"
 ARCH="amd64"
 TARBALL="zen.linux-x86_64.tar.xz"
 BUILD_DIR="${PACKAGE_NAME}_${VERSION}"

--- a/create-zen-deb.sh
+++ b/create-zen-deb.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # === CONFIG ===
-PACKAGE_NAME="zen-browser"
-VERSION="1.14.7b"
-ARCH="amd64"
 TARBALL="zen.linux-x86_64.tar.xz"
+PACKAGE_NAME="zen-browser"
+VERSION=$(tar -xJf ${TARBALL} --to-stdout zen/application.ini | grep '^Version=' | cut -d'=' -f2)
+ARCH="amd64"
 BUILD_DIR="${PACKAGE_NAME}_${VERSION}"
 INSTALL_DIR="$BUILD_DIR/opt/zen"
 BIN_DIR="$BUILD_DIR/usr/local/bin"

--- a/get-zen-install-deb.sh
+++ b/get-zen-install-deb.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 #
-# Time-stamp: <Tuesday 2025-07-29 08:15:18 +1000 Graham Williams>
+# Time-stamp: <Tuesday 2025-07-29 08:40:45 +1000 Graham Williams>
 #
-# Download the current distribution of zen for Linux and update the
-# create-zen-deb.sh script with the new version, ready to create and
-# then install a .deb.
-#
-# Author: Graham.Williams@togaware.com
+# Download the current distribution of zen for Linux, create the .deb
+# and then install the .deb.
 
 set -euo pipefail
 
@@ -26,14 +23,10 @@ wget --quiet --show-progress \
 
 VERSION=$(tar -xJf zen.linux-x86_64.tar.xz --to-stdout zen/application.ini | grep '^Version=' | cut -d'=' -f2)
 
-# Update the VERSION line in create-zen-deb.sh.
+# Create the .deb package.
 
-sed -i "s/VERSION=\"[^\"]*\"/VERSION=\"$VERSION\"/" create-zen-deb.sh
+bash create-zen-deb.sh
 
-echo
-echo "You can now create zen-browser_${VERSION}.deb to install the package:"
-echo
-echo "./create-zen-deb.sh"
-echo
-echo "sudo dpkg -i zen-browser_${VERSION}.deb"
-echo
+# Install the .deb package locally.
+
+sudo dpkg -i zen-browser_${VERSION}.deb

--- a/update-zen-deb.sh
+++ b/update-zen-deb.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Time-stamp: <Tuesday 2025-07-29 08:15:18 +1000 Graham Williams>
+#
+# Download the current distribution of zen for Linux and update the
+# create-zen-deb.sh script with the new version, ready to create and
+# then install a .deb.
+#
+# Author: Graham.Williams@togaware.com
+
+set -euo pipefail
+
+# Make a dated backup of any previously downloaded distribution file.
+
+if [ -e zen.linux-x86_64.tar.xz ]; then
+    mv zen.linux-x86_64.tar.xz zen.linux-x86_64.tar.xz.$(date +'%Y%m%d')
+fi
+
+# Download the latest release of zen.
+
+wget --quiet --show-progress \
+     https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.xz \
+     -O zen.linux-x86_64.tar.xz
+
+# Extract the version from the downloaded file.
+
+VERSION=$(tar -xJf zen.linux-x86_64.tar.xz --to-stdout zen/application.ini | grep '^Version=' | cut -d'=' -f2)
+
+# Update the VERSION line in create-zen-deb.sh.
+
+sed -i "s/VERSION=\"[^\"]*\"/VERSION=\"$VERSION\"/" create-zen-deb.sh
+
+echo
+echo "You can now create zen-browser_${VERSION}.deb to install the package:"
+echo
+echo "./create-zen-deb.sh"
+echo
+echo "sudo dpkg -i zen-browser_${VERSION}.deb"
+echo


### PR DESCRIPTION
The VERSION can be extracted from the tar file so not even the version number needs to be changed in the `create-zen-deb.sh`.

I also added a new script that others may find useful once they trust the code and the downloaded tar. The script  `get-zen-install-deb.sh` will itself download the tar, create the deb, and install it.